### PR TITLE
Simplify template sentence structure

### DIFF
--- a/src/samples/template.em
+++ b/src/samples/template.em
@@ -8,7 +8,7 @@ To make text =small-caps= use equals.
 To make text `monospace` use back-ticks.
 To make text ==use a different font== use double equals.
 
-Verbatim text is written !between exclamation marks!, it's used to force emblem to parse that text as-is.
-To make headings use `!.h1!` to `!.h6{asdf}!`, or `!###!`
+Verbatim text is written !between exclamation marks! and is used to force emblem to parse that text as-is.
+To make headings use `!.h1!` to `!.h6{asdf}!` or `!#!` `!######!`
 
 To find out more, check out the docs.


### PR DESCRIPTION
The current template includes some punctuation usage which isn’t yet handled by Emblem (pending the upcoming re-work of the glue parsing system). This PR removes the problematic punctuation from the template for now.
